### PR TITLE
Add support for molly-guard

### DIFF
--- a/grub-reboot-picker/grub-reboot-picker.py
+++ b/grub-reboot-picker/grub-reboot-picker.py
@@ -108,6 +108,15 @@ def build_menu():
     menu.show_all()
     return menu
 
+# Returns the correct version of the given command, depending on whether
+# molly-guard is installed.
+def molly_command(command):
+    molly_command = "/sbin/{}.no-molly-guard".format(command)
+    if os.path.exists(molly_command):
+        return molly_command
+    else:
+        # Maybe this should return "/sbin/command"
+        return command
 
 def do_grub_reboot(menuitem, grub_entry, parent_grub_entry=None):
     if parent_grub_entry is not None:
@@ -115,17 +124,20 @@ def do_grub_reboot(menuitem, grub_entry, parent_grub_entry=None):
     else:
         grub_reboot_value = "{}".format(grub_entry)
 
-    if DEVELOPMENT_MODE:
-        print("pkexec grub-reboot '{}' && sleep 1 && pkexec reboot".format(grub_reboot_value))
-    if not DEVELOPMENT_MODE:
-        os.system("pkexec grub-reboot '{}' && sleep 1 && pkexec reboot".format(grub_reboot_value))
+    reboot_command = molly_command("reboot")
 
+    if DEVELOPMENT_MODE:
+        print("pkexec grub-reboot '{}' && sleep 1 && pkexec {}".format(grub_reboot_value, reboot_command))
+    if not DEVELOPMENT_MODE:
+        os.system("pkexec grub-reboot '{}' && sleep 1 && pkexec {}".format(grub_reboot_value, reboot_command))
 
 def do_shutdown(_):
+    shutdown_command = molly_command("shutdown")
+
     if DEVELOPMENT_MODE:
-        print("sleep 1 && pkexec shutdown -h now")
+        print("sleep 1 && pkexec {} -h now".format(shutdown_command))
     if not DEVELOPMENT_MODE:
-        os.system("sleep 1 && pkexec shutdown -h now")
+        os.system("sleep 1 && pkexec {} -h now".format(shutdown_command))
 
 
 def quit(_):


### PR DESCRIPTION
Update the script to always call the "unguarded" versions of reboot and shutdown, if molly-guard is installed.

Molly-guard is a package that replaces the reboot and shutdown commands with "guarded" versions that prompt you before executing the command, to avoid accidentally rebooting the wrong system.  This is a common problem if you ssh into other systems and often reboot those systems.

Normally, molly-guard only triggers on an ssh login, but it can be configured to always trigger.  In this case, grub-reboot-picker triggers the guard when it tries to reboot or shut down, and that interrupts the actual reboot process.

Fixes #12 